### PR TITLE
fix handling of disabled retry locking + cleanup

### DIFF
--- a/pwdtk/auth_backends.py
+++ b/pwdtk/auth_backends.py
@@ -163,6 +163,8 @@ class MHPwdPolicyBackend(object):
             shall detect failed logins with username and password
             and lock out the user if too many login fails occured
         """
+        if PWDTK_USER_FAILURE_LIMIT is None:
+            return 0
         logger.debug("failed login for %s", username)
         data = self.userdata_cls(username=username)
         data.fail_time = datetime.datetime.utcnow().isoformat()

--- a/pwdtk/testproject/dj1/settings.py
+++ b/pwdtk/testproject/dj1/settings.py
@@ -61,10 +61,10 @@ ROOT_URLCONF = 'pwdtk.testproject.dj1.urls'
 # PWDTK specifics
 # For MH authentification back end
 # TODO: refactor and move into separate app
-import pwdtk.auth_backends_settings  # noqa E402
-pwdtk.auth_backends_settings.add_backend(AUTHENTICATION_BACKENDS)
-pwdtk.auth_backends_settings.add_middlewares(MIDDLEWARE)
-from pwdtk.auth_backends_settings import *  # noqa F401
+import pwdtk.settings  # noqa E402
+pwdtk.settings.add_backend(AUTHENTICATION_BACKENDS)
+pwdtk.settings.add_middlewares(MIDDLEWARE)
+from pwdtk.settings import *  # noqa F401
 
 
 TEMPLATES = [

--- a/pwdtk/testproject/dj18/settings.py
+++ b/pwdtk/testproject/dj18/settings.py
@@ -65,12 +65,10 @@ MIDDLEWARE_CLASSES = [
 ROOT_URLCONF = 'pwdtk.testproject.dj18.urls'
 
 # PWDTK specifics
-# For MH authentification back end
-# TODO: refactor and move into separate app
-import pwdtk.auth_backends_settings  # noqa E402
-pwdtk.auth_backends_settings.add_backend(AUTHENTICATION_BACKENDS)
-pwdtk.auth_backends_settings.add_middlewares(MIDDLEWARE_CLASSES)
-from pwdtk.auth_backends_settings import *  # noqa F401
+import pwdtk.settings  # noqa E402
+pwdtk.settings.add_backend(AUTHENTICATION_BACKENDS)
+pwdtk.settings.add_middlewares(MIDDLEWARE_CLASSES)
+from pwdtk.settings import *  # noqa F401
 
 
 TEMPLATES = [

--- a/pwdtk/testproject/dj21/settings.py
+++ b/pwdtk/testproject/dj21/settings.py
@@ -62,9 +62,9 @@ ROOT_URLCONF = 'pwdtk.testproject.dj21.urls'
 # PWDTK specifics
 # For MH authentification back end
 # TODO: refactor and move into separate app
-import pwdtk.auth_backends_settings  # noqa E402
-pwdtk.auth_backends_settings.add_backend(AUTHENTICATION_BACKENDS)
-from pwdtk.auth_backends_settings import *  # noqa F401
+import pwdtk.settings  # noqa E402
+pwdtk.settings.add_backend(AUTHENTICATION_BACKENDS)
+from pwdtk.settings import *  # noqa F401
 
 TEMPLATES = [
     {

--- a/pwdtk/watchers.py
+++ b/pwdtk/watchers.py
@@ -2,7 +2,7 @@ import datetime
 import logging
 import os
 
-from pwdtk.auth_backends_settings import PWDTK_PASSWD_HISTORY_LEN
+from pwdtk.settings import PWDTK_PASSWD_HISTORY_LEN
 
 
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
retry locking can be disabled by setting PWDTK_USER_FAILURE_LIMIT to None
now code doesn't fail if this is done.

all imports from pwdtk.auth_backends_settings changed to
imports from pwdtk.settings